### PR TITLE
feat: support to change what to show as display name

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -41,7 +41,25 @@
                 "help_text": "PIN that will be used for all the VMRs.",
                 "placeholder": "e.g. 4578",
                 "default": "1234"
-            }, {
+            },
+            {
+                "key": "DisplayNameType",
+                "display_name": "Display name:",
+                "type": "dropdown",
+                "help_text": "Select text to show as display name. If the value is empty for a user, it will use the username as a fallback.",
+                "default": "username",
+                "options": [{
+                    "display_name": "Username",
+                    "value": "username"
+                }, {
+                    "display_name": "Nickname",
+                    "value": "nickname"
+                }, {
+                    "display_name": "First and last name",
+                    "value": "firstAndLastName"
+                }]
+            },
+            {
                 "key": "Embedded",
                 "display_name": "Embedded Experience",
                 "type": "bool",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -22,10 +22,11 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	Node     string
-	Prefix   string
-	Pin      int
-	Embedded bool
+	Node            string
+	Prefix          string
+	Pin             int
+	DisplayNameType string
+	Embedded        bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/http.go
+++ b/server/http.go
@@ -33,15 +33,17 @@ func (p *Plugin) initializeRouter() {
 func (p *Plugin) httpGetSettings(w http.ResponseWriter, _ *http.Request) (int, error) {
 	conf := p.getConfiguration()
 	return respondJSON(w, struct {
-		Node     string `json:"node"`
-		Prefix   string `json:"prefix"`
-		Pin      int    `json:"pin"`
-		Embedded bool   `json:"embedded"`
+		Node            string `json:"node"`
+		Prefix          string `json:"prefix"`
+		Pin             int    `json:"pin"`
+		DisplayNameType string `json:"displayNameType"`
+		Embedded        bool   `json:"embedded"`
 	}{
-		Node:     conf.Node,
-		Prefix:   conf.Prefix,
-		Pin:      conf.Pin,
-		Embedded: conf.Embedded,
+		Node:            conf.Node,
+		Prefix:          conf.Prefix,
+		Pin:             conf.Pin,
+		DisplayNameType: conf.DisplayNameType,
+		Embedded:        conf.Embedded,
 	})
 }
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -9,7 +9,7 @@ import { Client4 } from 'mattermost-redux/client'
 import { ConferenceManager, type ConferenceConfig } from './services/conference-manager'
 import { App } from './App'
 import { MattermostManager } from './services/mattermost-manager'
-import { getPluginServerRoute, getPluginSettings, notifyJoinConference } from './utils'
+import { DisplayNameType, getPluginServerRoute, getPluginSettings, notifyJoinConference } from './utils'
 import { getConfig } from 'mattermost-redux/selectors/entities/general'
 
 import manifest from '../../plugin.json'
@@ -40,9 +40,26 @@ class Plugin {
       Client4.setUrl(config.SiteURL)
     }
     const user = await Client4.getUser(channelMembership.user_id)
+
+    let displayName = user.username
+    switch (pluginConfig.displayNameType) {
+      case DisplayNameType.Nickname: {
+        if (user.nickname !== '') {
+          displayName = user.nickname
+        }
+        break
+      }
+      case DisplayNameType.FirstAndLastName: {
+        const realName = `${user.first_name} ${user.last_name}`.trim()
+        if (realName !== '') {
+          displayName = realName
+        }
+      }
+    }
+
     const conferenceConfig: ConferenceConfig = {
       node: pluginConfig.node,
-      displayName: user.username,
+      displayName,
       vmrPrefix: pluginConfig.prefix,
       hostPin: pluginConfig.pin.toString()
     }
@@ -54,7 +71,7 @@ class Plugin {
       notifyJoinConference(this.store.getState(), channel.id).catch((error) => {
         console.error(error)
       })
-      window.open(`https://${pluginConfig.node}/webapp3/m/${vmr}/express?pin=${pluginConfig.pin}&name=${user.username}`,
+      window.open(`https://${pluginConfig.node}/webapp3/m/${vmr}/express?pin=${pluginConfig.pin}&name=${displayName}`,
         '', 'width=800;height=800')
     }
   }

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -3,10 +3,17 @@ import type { GlobalState } from 'mattermost-redux/types/store'
 import manifest from '../../plugin.json'
 import { Client4 } from 'mattermost-redux/client'
 
+export enum DisplayNameType {
+  Username = 'username',
+  Nickname = 'nickname',
+  FirstAndLastName = 'firstAndLastName'
+}
+
 interface PluginSettings {
   node: string
   prefix: string
   pin: number
+  displayNameType: DisplayNameType
   embedded: boolean
 }
 


### PR DESCRIPTION
The goal was to display the "First and last name" as display name instead of the username. Now this parameter is configurable. We can choose any of these:

- Username
- Nickname
- First and last name

In case any of these values is empty, we will use the username as a fallback.