### PR TITLE
Show state in participant list

### DIFF
--- a/webapp/src/components/Conference/ParticipantList/ParticipantList.scss
+++ b/webapp/src/components/Conference/ParticipantList/ParticipantList.scss
@@ -45,14 +45,7 @@
         display: flex;
         align-items: center;
         gap: 1em;
-
-        /* Center the icon */
-        > div {
-          display: flex;
-        }
-        > div > div > div {
-          display: flex;
-        }
+        line-height: 0;
       }
 
       &:hover {

--- a/webapp/src/components/Conference/ParticipantList/ParticipantList.scss
+++ b/webapp/src/components/Conference/ParticipantList/ParticipantList.scss
@@ -36,6 +36,11 @@
         flex-grow: 1;
       }
 
+      .AdmitButton {
+        min-height: 2em;
+        padding:  0 0.8em;
+      }
+
       .ParticipantStatus {
         display: flex;
         align-items: center;

--- a/webapp/src/components/Conference/ParticipantList/ParticipantList.scss
+++ b/webapp/src/components/Conference/ParticipantList/ParticipantList.scss
@@ -20,14 +20,35 @@
     margin: 0;
     padding: 8px;
     overflow: auto;
+    flex-grow: 1;
   
     li {
       list-style: none;
       color: #0a2136;
-      padding-left: 8px;
+      padding: 0 8px;
       height: 32px;
       line-height: 32px;
       cursor: default;
+      display: flex;
+      border-radius: 8px;
+
+      .ParticipantName {
+        flex-grow: 1;
+      }
+
+      .ParticipantStatus {
+        display: flex;
+        align-items: center;
+        gap: 1em;
+
+        /* Center the icon */
+        > div {
+          display: flex;
+        }
+        > div > div > div {
+          display: flex;
+        }
+      }
 
       &:hover {
         background-color: #f4f7fb;

--- a/webapp/src/components/Conference/ParticipantList/ParticipantList.test.tsx
+++ b/webapp/src/components/Conference/ParticipantList/ParticipantList.test.tsx
@@ -3,11 +3,12 @@ import { render, screen } from '@testing-library/react'
 import { ParticipantList } from './ParticipantList'
 
 jest.mock('@pexip/components', () => ({
+  Button: (props: any) => <button {...props}>{props.children}</button>,
   Icon: (props: any) => <div {...props} />,
   IconTypes: {
-    IconMicrophoneOff: '',
-    IconVideoOff: '',
-    IconPresentationOn: ''
+    IconMicrophoneOff: 'icon-microphone-off',
+    IconVideoOff: 'icon-video-off',
+    IconPresentationOn: 'icon-presentation-on'
   }
 }))
 
@@ -40,7 +41,8 @@ beforeEach(() => {
           displayName: 'Test User',
           isMuted: false,
           isCameraMuted: false,
-          isPresenting: false
+          isPresenting: false,
+          isWaiting: false
         }
       ]
     }
@@ -56,9 +58,36 @@ describe('ParticipantList', () => {
 
   it("shouldn't display any state by default", () => {
     render(<ParticipantList />)
+    const admitButton = screen.queryByTestId('AdmitButton')
     const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
     const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
     const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(admitButton).not.toBeInTheDocument()
+    expect(microphoneMutedIcon).not.toBeInTheDocument()
+    expect(cameraMutedIcon).not.toBeInTheDocument()
+    expect(presentingIcon).not.toBeInTheDocument()
+  })
+
+  it('should display the admit button icon when a participant is waiting', () => {
+    mockUseConferenceContext.mockReturnValue({
+      state: {
+        participants: [
+          {
+            displayName: 'Test User',
+            isWaiting: true,
+            isMuted: false,
+            isCameraMuted: false,
+            isPresenting: false
+          }
+        ]
+      }
+    })
+    render(<ParticipantList />)
+    const admitButton = screen.queryByTestId('AdmitButton')
+    const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
+    const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
+    const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(admitButton).toBeInTheDocument()
     expect(microphoneMutedIcon).not.toBeInTheDocument()
     expect(cameraMutedIcon).not.toBeInTheDocument()
     expect(presentingIcon).not.toBeInTheDocument()
@@ -70,6 +99,7 @@ describe('ParticipantList', () => {
         participants: [
           {
             displayName: 'Test User',
+            isWaiting: false,
             isMuted: true,
             isCameraMuted: false,
             isPresenting: false
@@ -78,9 +108,11 @@ describe('ParticipantList', () => {
       }
     })
     render(<ParticipantList />)
+    const admitButton = screen.queryByTestId('AdmitButton')
     const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
     const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
     const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(admitButton).not.toBeInTheDocument()
     expect(microphoneMutedIcon).toBeInTheDocument()
     expect(cameraMutedIcon).not.toBeInTheDocument()
     expect(presentingIcon).not.toBeInTheDocument()
@@ -92,6 +124,7 @@ describe('ParticipantList', () => {
         participants: [
           {
             displayName: 'Test User',
+            isWaiting: false,
             isMuted: false,
             isCameraMuted: true,
             isPresenting: false
@@ -100,9 +133,11 @@ describe('ParticipantList', () => {
       }
     })
     render(<ParticipantList />)
+    const admitButton = screen.queryByTestId('AdmitButton')
     const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
     const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
     const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(admitButton).not.toBeInTheDocument()
     expect(microphoneMutedIcon).not.toBeInTheDocument()
     expect(cameraMutedIcon).toBeInTheDocument()
     expect(presentingIcon).not.toBeInTheDocument()
@@ -114,6 +149,7 @@ describe('ParticipantList', () => {
         participants: [
           {
             displayName: 'Test User',
+            isWaiting: false,
             isMuted: false,
             isCameraMuted: false,
             isPresenting: true
@@ -122,9 +158,11 @@ describe('ParticipantList', () => {
       }
     })
     render(<ParticipantList />)
+    const admitButton = screen.queryByTestId('AdmitButton')
     const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
     const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
     const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(admitButton).not.toBeInTheDocument()
     expect(microphoneMutedIcon).not.toBeInTheDocument()
     expect(cameraMutedIcon).not.toBeInTheDocument()
     expect(presentingIcon).toBeInTheDocument()
@@ -136,12 +174,14 @@ describe('ParticipantList', () => {
         participants: [
           {
             displayName: 'Test User',
+            isWaiting: false,
             isMuted: true,
             isCameraMuted: false,
             isPresenting: false
           },
           {
             displayName: 'Test User 2',
+            isWaiting: false,
             isMuted: true,
             isCameraMuted: false,
             isPresenting: false
@@ -150,9 +190,11 @@ describe('ParticipantList', () => {
       }
     })
     render(<ParticipantList />)
+    const admitButton = screen.queryByTestId('AdmitButton')
     const microphoneMutedIcon = screen.queryAllByTestId('MicrophoneMutedIcon')
     const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
     const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(admitButton).not.toBeInTheDocument()
     expect(microphoneMutedIcon.length).toBe(2)
     expect(cameraMutedIcon).not.toBeInTheDocument()
     expect(presentingIcon).not.toBeInTheDocument()

--- a/webapp/src/components/Conference/ParticipantList/ParticipantList.test.tsx
+++ b/webapp/src/components/Conference/ParticipantList/ParticipantList.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ParticipantList } from './ParticipantList'
+
+jest.mock('@pexip/components', () => ({
+  Icon: (props: any) => <div {...props} />,
+  IconTypes: {
+    IconMicrophoneOff: '',
+    IconVideoOff: '',
+    IconPresentationOn: ''
+  }
+}))
+
+jest.mock(
+  '@pexip/infinity',
+  () => ({
+    Participant: {
+      displayName: 'Test User',
+      isMuted: true,
+      isCameraMuted: true,
+      isPresenting: true
+    }
+  }),
+  { virtual: true }
+)
+const mockUseConferenceContext = jest.fn()
+jest.mock('@contexts/ConferenceContext/ConferenceContext', () => ({
+  useConferenceContext: () => mockUseConferenceContext()
+}))
+
+jest.mock('@components/Tooltip/Tooltip', () => ({
+  Tooltip: (props: any) => <div>{props.children}</div>
+}))
+
+beforeEach(() => {
+  mockUseConferenceContext.mockReturnValue({
+    state: {
+      participants: [
+        {
+          displayName: 'Test User',
+          isMuted: false,
+          isCameraMuted: false,
+          isPresenting: false
+        }
+      ]
+    }
+  })
+})
+
+describe('ParticipantList', () => {
+  it('should render', () => {
+    render(<ParticipantList />)
+    const participantList = screen.getByTestId('ParticipantList')
+    expect(participantList).toBeInTheDocument()
+  })
+
+  it("shouldn't display any state by default", () => {
+    render(<ParticipantList />)
+    const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
+    const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
+    const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(microphoneMutedIcon).not.toBeInTheDocument()
+    expect(cameraMutedIcon).not.toBeInTheDocument()
+    expect(presentingIcon).not.toBeInTheDocument()
+  })
+
+  it('should display the muted microphone icon when a participant is muted', () => {
+    mockUseConferenceContext.mockReturnValue({
+      state: {
+        participants: [
+          {
+            displayName: 'Test User',
+            isMuted: true,
+            isCameraMuted: false,
+            isPresenting: false
+          }
+        ]
+      }
+    })
+    render(<ParticipantList />)
+    const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
+    const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
+    const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(microphoneMutedIcon).toBeInTheDocument()
+    expect(cameraMutedIcon).not.toBeInTheDocument()
+    expect(presentingIcon).not.toBeInTheDocument()
+  })
+
+  it("should display the muted camera icon when a participant's camera is muted", () => {
+    mockUseConferenceContext.mockReturnValue({
+      state: {
+        participants: [
+          {
+            displayName: 'Test User',
+            isMuted: false,
+            isCameraMuted: true,
+            isPresenting: false
+          }
+        ]
+      }
+    })
+    render(<ParticipantList />)
+    const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
+    const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
+    const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(microphoneMutedIcon).not.toBeInTheDocument()
+    expect(cameraMutedIcon).toBeInTheDocument()
+    expect(presentingIcon).not.toBeInTheDocument()
+  })
+
+  it('should display the screen sharing icon when a participant is presenting', () => {
+    mockUseConferenceContext.mockReturnValue({
+      state: {
+        participants: [
+          {
+            displayName: 'Test User',
+            isMuted: false,
+            isCameraMuted: false,
+            isPresenting: true
+          }
+        ]
+      }
+    })
+    render(<ParticipantList />)
+    const microphoneMutedIcon = screen.queryByTestId('MicrophoneMutedIcon')
+    const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
+    const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(microphoneMutedIcon).not.toBeInTheDocument()
+    expect(cameraMutedIcon).not.toBeInTheDocument()
+    expect(presentingIcon).toBeInTheDocument()
+  })
+
+  it('should display several muted icons if at least two participants are muted', () => {
+    mockUseConferenceContext.mockReturnValue({
+      state: {
+        participants: [
+          {
+            displayName: 'Test User',
+            isMuted: true,
+            isCameraMuted: false,
+            isPresenting: false
+          },
+          {
+            displayName: 'Test User 2',
+            isMuted: true,
+            isCameraMuted: false,
+            isPresenting: false
+          }
+        ]
+      }
+    })
+    render(<ParticipantList />)
+    const microphoneMutedIcon = screen.queryAllByTestId('MicrophoneMutedIcon')
+    const cameraMutedIcon = screen.queryByTestId('CameraMutedIcon')
+    const presentingIcon = screen.queryByTestId('PresentingIcon')
+    expect(microphoneMutedIcon.length).toBe(2)
+    expect(cameraMutedIcon).not.toBeInTheDocument()
+    expect(presentingIcon).not.toBeInTheDocument()
+  })
+})

--- a/webapp/src/components/Conference/ParticipantList/ParticipantList.tsx
+++ b/webapp/src/components/Conference/ParticipantList/ParticipantList.tsx
@@ -1,17 +1,41 @@
 import React from 'react'
-
+import { Icon, IconTypes } from '@pexip/components'
 import type { Participant } from '@pexip/infinity'
 import { useConferenceContext } from '@contexts/ConferenceContext/ConferenceContext'
+import { Tooltip } from '@components/Tooltip/Tooltip'
 
 import './ParticipantList.scss'
 
 export const ParticipantList = (): JSX.Element => {
   const { state } = useConferenceContext()
 
-  return <div className='ParticipantList'>
-    <h3>Participants</h3>
-    <ul>
-      {state.participants.map((participant: Participant, index: number) => <li key={index}>{ participant.displayName }</li>)}
-    </ul>
-  </div>
+  return (
+    <div className='ParticipantList' data-testid='ParticipantList'>
+      <h3>Participants</h3>
+      <ul>
+        {state.participants.map((participant: Participant, index: number) => (
+          <li key={index}>
+            <span className='ParticipantName'>{participant.displayName}</span>
+            <div className='ParticipantStatus'>
+              {participant.isMuted && (
+                <Tooltip text='Microphone muted' position='bottomLeft'>
+                  <Icon source={IconTypes.IconMicrophoneOff} data-testid='MicrophoneMutedIcon' />
+                </Tooltip>
+              )}
+              {participant.isCameraMuted && (
+                <Tooltip text='Camera muted' position='bottomLeft'>
+                  <Icon source={IconTypes.IconVideoOff} data-testid='CameraMutedIcon' />
+                </Tooltip>
+              )}
+              {participant.isPresenting && (
+                <Tooltip text='Sharing screen' position='bottomLeft'>
+                  <Icon source={IconTypes.IconPresentationOn} data-testid='PresentingIcon' />
+                </Tooltip>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }

--- a/webapp/src/components/Conference/ParticipantList/ParticipantList.tsx
+++ b/webapp/src/components/Conference/ParticipantList/ParticipantList.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Icon, IconTypes } from '@pexip/components'
+import { Button, Icon, IconTypes } from '@pexip/components'
 import type { Participant } from '@pexip/infinity'
 import { useConferenceContext } from '@contexts/ConferenceContext/ConferenceContext'
 import { Tooltip } from '@components/Tooltip/Tooltip'
@@ -9,6 +9,10 @@ import './ParticipantList.scss'
 export const ParticipantList = (): JSX.Element => {
   const { state } = useConferenceContext()
 
+  const handleAdmitParticipant = async (participant: Participant): Promise<void> => {
+    await state.client?.admit({ participantUuid: participant.uuid })
+  }
+
   return (
     <div className='ParticipantList' data-testid='ParticipantList'>
       <h3>Participants</h3>
@@ -17,6 +21,21 @@ export const ParticipantList = (): JSX.Element => {
           <li key={index}>
             <span className='ParticipantName'>{participant.displayName}</span>
             <div className='ParticipantStatus'>
+              {participant.isWaiting && (
+                <Tooltip text='Admit guest participant' position='bottomLeft'>
+                  <Button
+                    variant='secondary'
+                    colorScheme='light'
+                    className='AdmitButton'
+                    data-testid='AdmitButton'
+                    onClick={() => {
+                      handleAdmitParticipant(participant).catch(console.error)
+                    }}
+                  >
+                    Admit
+                  </Button>
+                </Tooltip>
+              )}
               {participant.isMuted && (
                 <Tooltip text='Microphone muted' position='bottomLeft'>
                   <Icon source={IconTypes.IconMicrophoneOff} data-testid='MicrophoneMutedIcon' />

--- a/webapp/src/components/Tooltip/Tooltip.scss
+++ b/webapp/src/components/Tooltip/Tooltip.scss
@@ -4,7 +4,6 @@
   opacity: 0.9;
   font-size: 12px;
   padding: 4px 8px;
-  border-radius: 4px;
   white-space: nowrap;
   height: fit-content;
 

--- a/webapp/src/components/Tooltip/Tooltip.tsx
+++ b/webapp/src/components/Tooltip/Tooltip.tsx
@@ -15,7 +15,9 @@ export const Tooltip = (props: TooltipProps): JSX.Element => {
   const position = props.position ?? 'topCenter'
   return (
     <div className={props.className}>
-      <CustomTooltip className='Tooltip' content={props.text} isArrowShown position={position}>{props.children}</CustomTooltip>
+      <CustomTooltip className='Tooltip' content={props.text} isArrowShown position={position}>
+        {props.children}
+      </CustomTooltip>
     </div>
   )
 }

--- a/webapp/src/contexts/ConferenceContext/methods/togglePresenting.ts
+++ b/webapp/src/contexts/ConferenceContext/methods/togglePresenting.ts
@@ -1,14 +1,29 @@
 import { ConferenceActionType, type ConferenceAction } from '../ConferenceAction'
 import { type ConferenceState } from '../ConferenceState'
 
-export const toggleMutePresenting = async (state: ConferenceState, dispatch: React.Dispatch<ConferenceAction>): Promise<void> => {
+export const toggleMutePresenting = async (
+  state: ConferenceState,
+  dispatch: React.Dispatch<ConferenceAction>
+): Promise<void> => {
   const { client, presenting } = state
 
   let presentationStream
   if (presenting) {
-    console.log('Stopping presentation')
+    state.presentationStream?.getTracks().forEach((track) => {
+      track.stop()
+    })
+    client?.stopPresenting()
   } else {
     presentationStream = await navigator.mediaDevices.getDisplayMedia()
+    presentationStream.getVideoTracks()[0].addEventListener('ended', () => {
+      client?.stopPresenting()
+      dispatch({
+        type: ConferenceActionType.TogglePresenting,
+        body: {
+          presenting: false
+        }
+      })
+    })
     client?.present(presentationStream)
   }
 


### PR DESCRIPTION
We display an icon near the participant that indicates the following information: 

- Admit button when the guest user is waiting.
- Audio mute state. 
- Video mute state. 
- Is presenting. 