### PR TITLE
feat: allow DM calling

### DIFF
--- a/webapp/src/components/JoinPanel/JoinPanel.tsx
+++ b/webapp/src/components/JoinPanel/JoinPanel.tsx
@@ -39,25 +39,13 @@ export const JoinPanel = (): JSX.Element => {
     return unsubscribe
   }, [])
 
-  const isChannel = channel?.team_id !== ''
 
-  let component
-  if (isChannel) {
-    component = <>
-      <p>Connect to {'"' + channel?.display_name + '"'} room? </p>
+  return (
+    <div className='JoinPanel'>
+      <p>Connect to {channel?.display_name !== '' ? '"' + channel?.display_name + '"' : 'Direct'} room? </p>
       <button onClick={ () => { handleConnect().catch((e) => { console.error(e) }) }}>
         Join conference
       </button>
-    </>
-  } else {
-    component = <>
-      <p>Video conferences are only available for Channels.</p>
-      <p>Select a channel to start!</p>
-    </>
-  }
-  return (
-    <div className='JoinPanel'>
-      {component}
     </div>
   )
 }


### PR DESCRIPTION
Allow DM calling.
Currently we use `name` we could consider using `id` too.

![image](https://github.com/pexip/pexip-mattermost-plugin/assets/5301136/e8b5ab83-8ef2-49aa-81fd-68cca391daa0)
