### PR TITLE
fix: change devices and effect even if it is muted

### DIFF
--- a/webapp/src/components/Conference/Toolbar/Toolbar.tsx
+++ b/webapp/src/components/Conference/Toolbar/Toolbar.tsx
@@ -17,7 +17,8 @@ export const Toolbar = (): JSX.Element => {
     presentationInPopUp,
     inputVideoDeviceId,
     inputAudioDeviceId,
-    outputAudioDeviceId
+    outputAudioDeviceId,
+    effect
   } = state
 
   return (
@@ -74,7 +75,7 @@ export const Toolbar = (): JSX.Element => {
               inputAudioDeviceId,
               inputVideoDeviceId,
               outputAudioDeviceId,
-              effect: state.effect
+              effect
             }).catch(console.error)
           }}
         >

--- a/webapp/src/contexts/ConferenceContext/ConferenceContext.test.tsx
+++ b/webapp/src/contexts/ConferenceContext/ConferenceContext.test.tsx
@@ -245,6 +245,8 @@ const ConferenceContextTester = (): JSX.Element => {
       <span data-testid='connectionState'>{state.connectionState}</span>
       <span data-testid='channel'>{JSON.stringify(state.channel)}</span>
       <span data-testid='errorMessage'>{state.errorMessage}</span>
+      <span data-testid='inputVideoDeviceId'>{state.inputVideoDeviceId}</span>
+      <span data-testid='inputAudioDeviceId'>{state.inputAudioDeviceId}</span>
       <span data-testid='outputAudioDeviceId'>{state.outputAudioDeviceId}</span>
       <span data-testid='effect'>{state.effect}</span>
       <span data-testid='audioMuted'>{state.audioMuted ? 'true' : 'false'}</span>
@@ -1168,6 +1170,50 @@ describe('ConferenceContext', () => {
         ]
       ])
     })
+
+    it('should change the inputVideoDeviceId in the state even when the video is muted', async () => {
+      render(
+        <ConferenceContextProvider>
+          <ConferenceContextTester />
+        </ConferenceContextProvider>
+      )
+      await act(async () => {
+        const button = screen.getByTestId('buttonConnect')
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        const button = screen.getByTestId('buttonToggleMuteVideo')
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        const button = screen.getByTestId('buttonChangeDevices')
+        fireEvent.click(button)
+      })
+      const effect = screen.getByTestId('inputVideoDeviceId')
+      expect(effect.innerHTML).toBe(mockDevicesIds.inputVideoDeviceId)
+    })
+
+    it('should change the inputAudioDeviceId in the state even when the audio is muted', async () => {
+      render(
+        <ConferenceContextProvider>
+          <ConferenceContextTester />
+        </ConferenceContextProvider>
+      )
+      await act(async () => {
+        const button = screen.getByTestId('buttonConnect')
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        const button = screen.getByTestId('buttonToggleMuteAudio')
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        const button = screen.getByTestId('buttonChangeDevices')
+        fireEvent.click(button)
+      })
+      const effect = screen.getByTestId('inputAudioDeviceId')
+      expect(effect.innerHTML).toBe(mockDevicesIds.inputAudioDeviceId)
+    })
   })
 
   describe('changeEffect', () => {
@@ -1261,6 +1307,28 @@ describe('ConferenceContext', () => {
       })
       expect(mockSetItem).toHaveBeenCalledTimes(1)
       expect(mockSetItem).toHaveBeenCalledWith(LocalStorageKey.effectKey, mockEffect)
+    })
+
+    it('should change the effect in the state even when the video is muted', async () => {
+      render(
+        <ConferenceContextProvider>
+          <ConferenceContextTester />
+        </ConferenceContextProvider>
+      )
+      await act(async () => {
+        const button = screen.getByTestId('buttonConnect')
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        const button = screen.getByTestId('buttonToggleMuteVideo')
+        fireEvent.click(button)
+      })
+      await act(async () => {
+        const button = screen.getByTestId('buttonChangeEffect')
+        fireEvent.click(button)
+      })
+      const effect = screen.getByTestId('effect')
+      expect(effect.innerHTML).toBe(mockEffect)
     })
   })
 })

--- a/webapp/src/contexts/ConferenceContext/ConferenceContext.tsx
+++ b/webapp/src/contexts/ConferenceContext/ConferenceContext.tsx
@@ -145,8 +145,16 @@ const ConferenceContextProvider = (props: any): JSX.Element => {
       },
       changeEffect: async (effect: Effect) => {
         localStorage.setItem(LocalStorageKey.effectKey, effect)
-        if (state.localVideoStream != null) {
+
+        if (!state.videoMuted && state.localVideoStream != null) {
           changeEffect(state.localVideoStream, effect, state, dispatch).catch(console.error)
+        } else {
+          dispatch({
+            type: ConferenceActionType.ChangeEffect,
+            body: {
+              effect
+            }
+          })
         }
       },
       state

--- a/webapp/src/contexts/ConferenceContext/ConferenceContext.tsx
+++ b/webapp/src/contexts/ConferenceContext/ConferenceContext.tsx
@@ -148,14 +148,14 @@ const ConferenceContextProvider = (props: any): JSX.Element => {
 
         if (!state.videoMuted && state.localVideoStream != null) {
           changeEffect(state.localVideoStream, effect, state, dispatch).catch(console.error)
-        } else {
-          dispatch({
-            type: ConferenceActionType.ChangeEffect,
-            body: {
-              effect
-            }
-          })
         }
+
+        dispatch({
+          type: ConferenceActionType.ChangeEffect,
+          body: {
+            effect
+          }
+        })
       },
       state
     }),

--- a/webapp/src/contexts/ConferenceContext/methods/changeDevices.ts
+++ b/webapp/src/contexts/ConferenceContext/methods/changeDevices.ts
@@ -32,21 +32,23 @@ export const changeDevices = async (
   })
 
   let newLocalVideoStream: MediaStream | null = null
-  if (!videoMuted && hasDeviceIdChanged(localVideoStream, inputVideoDeviceId)) {
-    newLocalVideoStream = await navigator.mediaDevices.getUserMedia({
-      video: { deviceId: inputVideoDeviceId }
-    })
+  if (hasDeviceIdChanged(localVideoStream, inputVideoDeviceId)) {
+    if (!videoMuted) {
+      newLocalVideoStream = await navigator.mediaDevices.getUserMedia({
+        video: { deviceId: inputVideoDeviceId }
+      })
 
-    localVideoStream?.getTracks().forEach((track) => {
-      track.stop()
-    })
+      localVideoStream?.getTracks().forEach((track) => {
+        track.stop()
+      })
 
-    dispatch({
-      type: ConferenceActionType.UpdateLocalStream,
-      body: {
-        localVideoStream: newLocalVideoStream
-      }
-    })
+      dispatch({
+        type: ConferenceActionType.UpdateLocalStream,
+        body: {
+          localVideoStream: newLocalVideoStream
+        }
+      })
+    }
 
     dispatch({
       type: ConferenceActionType.ChangeDevices,
@@ -57,21 +59,23 @@ export const changeDevices = async (
   }
 
   let newLocalAudioStream: MediaStream | null = null
-  if (!audioMuted && hasDeviceIdChanged(localAudioStream, inputAudioDeviceId)) {
-    newLocalAudioStream = await navigator.mediaDevices.getUserMedia({
-      audio: { deviceId: inputAudioDeviceId }
-    })
+  if (hasDeviceIdChanged(localAudioStream, inputAudioDeviceId)) {
+    if (!audioMuted) {
+      newLocalAudioStream = await navigator.mediaDevices.getUserMedia({
+        audio: { deviceId: inputAudioDeviceId }
+      })
 
-    localAudioStream?.getTracks().forEach((track) => {
-      track.stop()
-    })
+      localAudioStream?.getTracks().forEach((track) => {
+        track.stop()
+      })
 
-    dispatch({
-      type: ConferenceActionType.UpdateLocalStream,
-      body: {
-        localAudioStream: newLocalAudioStream
-      }
-    })
+      dispatch({
+        type: ConferenceActionType.UpdateLocalStream,
+        body: {
+          localAudioStream: newLocalAudioStream
+        }
+      })
+    }
 
     dispatch({
       type: ConferenceActionType.ChangeDevices,

--- a/webapp/src/contexts/ConferenceContext/methods/changeEffect.ts
+++ b/webapp/src/contexts/ConferenceContext/methods/changeEffect.ts
@@ -56,13 +56,6 @@ export const changeEffect = async (
     }
   })
 
-  dispatch({
-    type: ConferenceActionType.ChangeEffect,
-    body: {
-      effect
-    }
-  })
-
   return processedVideoStream
 }
 


### PR DESCRIPTION
If the audio and video were muted, the devices and effects settings were only saved in the `localStorage` and not in the `ConferenceState`. With this change it's saved also in the state, so if the user unmutes the camera, the proper effect will be applied.

Closes: https://pexiponfire.atlassian.net/browse/MAT-12