### PR TITLE
fix: change html font-size to 10px

### DIFF
--- a/webapp/src/App/App.scss
+++ b/webapp/src/App/App.scss
@@ -14,3 +14,11 @@
 .modal .about-modal .modal-body {
   overflow: unset;
 }
+
+/**
+ * The library "@pexip/components" overrides the font-size to 14px when Mattermost uses 10px.
+ * This is a workaround to fix the issue until the library is fixed.
+ */
+html {
+  font-size: 10px !important;
+}


### PR DESCRIPTION
The plugin overrides the html font-size from 10px to 14px. The reason for this is a dependency that it's imported. Since fixing this dependency will take a while, we need to modify the style in the plugin to use:

```css
html {
  font-size: 10px;
}
```