### PR TITLE
feat: make the join-leave notifications configurable

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -76,6 +76,13 @@
         "help_text": "Indicates if the conference should be displayed inside Mattermost or in another tab with only the conference."
       },
       {
+        "key": "ShowJoinLeaveNotifications",
+        "display_name": "Show Join/Leave Notifications:",
+        "type": "bool",
+        "help_text": "Indicates if the join/leave notifications should be shown in the channel.",
+        "default": false
+      },
+      {
         "key": "FilterChannels",
         "display_name": "Filter Channels:",
         "type": "custom",

--- a/plugin.json
+++ b/plugin.json
@@ -73,7 +73,8 @@
         "key": "Embedded",
         "display_name": "Embedded Experience:",
         "type": "bool",
-        "help_text": "Indicates if the conference should be displayed inside Mattermost or in another tab with only the conference."
+        "help_text": "Indicates if the conference should be displayed inside Mattermost or in another tab with only the conference.",
+        "default": true
       },
       {
         "key": "ShowJoinLeaveNotifications",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -23,12 +23,13 @@ type FilterChannels struct {
 }
 
 type configuration struct {
-	Node            string
-	Prefix          string
-	Pin             int
-	DisplayNameType string
-	Embedded        bool
-	FilterChannels  FilterChannels
+	Node                       string
+	Prefix                     string
+	Pin                        int
+	DisplayNameType            string
+	Embedded                   bool
+	ShowJoinLeaveNotifications bool
+	FilterChannels             FilterChannels
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/webapp/src/App/utils/http-requests.ts
+++ b/webapp/src/App/utils/http-requests.ts
@@ -18,6 +18,12 @@ export const getPluginServerRoute = (): string => {
 }
 
 export const notifyJoinConference = async (): Promise<void> => {
+  const settings = await getPluginSettings()
+
+  if (!settings.showJoinLeaveNotifications) {
+    return
+  }
+
   const baseUrl = getPluginServerRoute()
   const channelId = getMattermostStore().getState().entities.channels.currentChannelId
   await fetch(
@@ -30,6 +36,12 @@ export const notifyJoinConference = async (): Promise<void> => {
 }
 
 export const notifyLeaveConference = async (): Promise<void> => {
+  const settings = await getPluginSettings()
+
+  if (!settings.showJoinLeaveNotifications) {
+    return
+  }
+
   const baseUrl = getPluginServerRoute()
   const channelId = getMattermostStore().getState().entities.channels.currentChannelId
   await fetch(

--- a/webapp/src/types/PluginSettings.ts
+++ b/webapp/src/types/PluginSettings.ts
@@ -6,6 +6,7 @@ export interface PluginSettings {
   pin: number
   displayNameType: DisplayNameType
   embedded: boolean
+  showJoinLeaveNotifications: boolean
   filterChannels: {
     enabled: boolean
     allowedChannels: string[]


### PR DESCRIPTION
Performed the following tasks:

- Include a new parameter in the settings: `ShowJoinLeaveNotifications` that by default is `false`.
- No send the notifications HTTP request in the frontend if the feature is disabled.
- Disable also the messages in the backend if the feature is disabled. In this case we return a 403 error with a descriptive message.

An additional task:

- Set the embedded experience enabled by default.