### PR TITLE
fix: display the leave notification message in the conference channel

### DIFF
--- a/webapp/src/App/contexts/ConferenceContext/ConferenceReducer.ts
+++ b/webapp/src/App/contexts/ConferenceContext/ConferenceReducer.ts
@@ -88,7 +88,10 @@ export const ConferenceReducer = (prevState: ConferenceState, action: Conference
         track.stop()
       })
 
-      notifyLeaveConference().catch(console.error)
+      const channelId = prevState.channel?.id
+      if (channelId != null) {
+        notifyLeaveConference(channelId).catch(console.error)
+      }
 
       return {
         ...prevState,

--- a/webapp/src/App/utils/http-requests.ts
+++ b/webapp/src/App/utils/http-requests.ts
@@ -29,9 +29,8 @@ export const notifyJoinConference = async (): Promise<void> => {
   )
 }
 
-export const notifyLeaveConference = async (): Promise<void> => {
+export const notifyLeaveConference = async (channelId: string): Promise<void> => {
   const baseUrl = getPluginServerRoute()
-  const channelId = getMattermostStore().getState().entities.channels.currentChannelId
   await fetch(
     `${baseUrl}/api/notify_leave_conference`,
     Client4.getOptions({


### PR DESCRIPTION
Read the current channel from the `ConferenceState` and pass it to the `notifyLeaveConference` function.