### PR TITLE
fix: disconnect from conference after user clicks on X or close the window

### DIFF
--- a/webapp/src/App/App.tsx
+++ b/webapp/src/App/App.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react'
-
+import React, { useEffect, useRef } from 'react'
 import type { ConferenceConfig } from '../types/ConferenceConfig'
 import { useConferenceContext } from './contexts/ConferenceContext/ConferenceContext'
 import { ConnectionState } from '../types/ConnectionState'
@@ -9,7 +8,6 @@ import { Loading } from './components/Loading/Loading'
 import { ErrorPanel } from './components/ErrorPanel/ErrorPanel'
 
 import './App.scss'
-
 interface AppProps {
   config: ConferenceConfig
 }
@@ -17,10 +15,16 @@ interface AppProps {
 export const App = (props: AppProps): JSX.Element => {
   const { setConfig, disconnect, state } = useConferenceContext()
 
+  const disconnectRef = useRef<() => Promise<void>>()
+
+  useEffect(() => {
+    disconnectRef.current = disconnect
+  }, [state, disconnect])
+
   useEffect(() => {
     setConfig(props.config)
     return () => {
-      disconnect().catch(console.error)
+      disconnectRef.current?.().catch(console.error)
     }
   }, [])
 

--- a/webapp/src/App/contexts/ConferenceContext/ConferenceContext.tsx
+++ b/webapp/src/App/contexts/ConferenceContext/ConferenceContext.tsx
@@ -70,11 +70,6 @@ interface ConferenceContextProviderProps {
 const ConferenceContextProvider = (props: ConferenceContextProviderProps): JSX.Element => {
   const [state, dispatch] = useReducer(ConferenceReducer, initialState)
 
-  const beforeUnloadHandler = (): void => {
-    const disconnectReason: DisconnectReason = 'Browser closed'
-    disconnect(state, dispatch, disconnectReason).catch(console.error)
-  }
-
   const handleDeviceChange = (): void => {
     console.log('Device change detected')
     filterMediaDevices({
@@ -116,6 +111,19 @@ const ConferenceContextProvider = (props: ConferenceContextProviderProps): JSX.E
     }
   }, [state])
 
+  useEffect(() => {
+    const beforeUnloadHandler = (): void => {
+      const disconnectReason: DisconnectReason = 'Browser closed'
+      disconnect(state, dispatch, disconnectReason).catch(console.error)
+    }
+    if (state.connectionState === ConnectionState.Connected) {
+      addEventListener('beforeunload', beforeUnloadHandler)
+    }
+    return () => {
+      removeEventListener('beforeunload', beforeUnloadHandler)
+    }
+  }, [state.connectionState])
+
   const value = useMemo(
     () => ({
       setConfig: (config: ConferenceConfig): void => {
@@ -140,12 +148,13 @@ const ConferenceContextProvider = (props: ConferenceContextProviderProps): JSX.E
         } catch (e) {
           console.error(e)
         }
-        addEventListener('beforeunload', beforeUnloadHandler)
       },
       disconnect: async () => {
-        const disconnectReason: DisconnectReason = 'User initiated disconnect'
-        disconnect(state, dispatch, disconnectReason).catch(console.error)
-        removeEventListener('beforeunload', beforeUnloadHandler)
+        if (state.connectionState === ConnectionState.Disconnected) {
+          return
+        }
+        const reason: DisconnectReason = 'User initiated disconnect'
+        disconnect(state, dispatch, reason).catch(console.error)
       },
       toggleMuteAudio: async () => {
         toggleMuteAudio(state, dispatch).catch(console.error)

--- a/webapp/src/App/contexts/ConferenceContext/ConferenceReducer.ts
+++ b/webapp/src/App/contexts/ConferenceContext/ConferenceReducer.ts
@@ -1,8 +1,6 @@
-import { notifyJoinConference, notifyLeaveConference } from '../../utils/http-requests'
 import { ConnectionState } from '../../../types/ConnectionState'
 import { ConferenceActionType, type ConferenceAction } from './ConferenceAction'
 import type { ConferenceState } from './ConferenceState'
-import { closePopUp } from './methods/togglePresentationInPopUp'
 import { CallType, type Participant } from '@pexip/infinity'
 
 export const ConferenceReducer = (prevState: ConferenceState, action: ConferenceAction): ConferenceState => {
@@ -29,8 +27,6 @@ export const ConferenceReducer = (prevState: ConferenceState, action: Conference
       }
     }
     case ConferenceActionType.Connected: {
-      closePopUp()
-      notifyJoinConference().catch(console.error)
       return {
         ...prevState,
         connectionState: ConnectionState.Connected,
@@ -77,19 +73,6 @@ export const ConferenceReducer = (prevState: ConferenceState, action: Conference
     }
 
     case ConferenceActionType.Disconnected: {
-      closePopUp()
-      prevState.localVideoStream?.getTracks().forEach((track) => {
-        track.stop()
-      })
-      prevState.localAudioStream?.getTracks().forEach((track) => {
-        track.stop()
-      })
-      prevState.presentationStream?.getTracks().forEach((track) => {
-        track.stop()
-      })
-
-      notifyLeaveConference().catch(console.error)
-
       return {
         ...prevState,
         localVideoStream: undefined,

--- a/webapp/src/App/contexts/ConferenceContext/ConferenceReducer.ts
+++ b/webapp/src/App/contexts/ConferenceContext/ConferenceReducer.ts
@@ -51,7 +51,6 @@ export const ConferenceReducer = (prevState: ConferenceState, action: Conference
         ...(outputAudioDeviceId != null && { outputAudioDeviceId })
       }
     }
-
     case ConferenceActionType.UpdateLocalStream: {
       const localVideoStream: MediaStream = action.body.localVideoStream
       const localAudioStream: MediaStream = action.body.localAudioStream
@@ -64,14 +63,12 @@ export const ConferenceReducer = (prevState: ConferenceState, action: Conference
         ...(processedVideoStream != null && { processedVideoStream })
       }
     }
-
     case ConferenceActionType.ChangeEffect: {
       return {
         ...prevState,
         effect: action.body.effect
       }
     }
-
     case ConferenceActionType.Disconnected: {
       return {
         ...prevState,

--- a/webapp/src/App/contexts/ConferenceContext/methods/connect.ts
+++ b/webapp/src/App/contexts/ConferenceContext/methods/connect.ts
@@ -3,6 +3,8 @@ import { ConferenceActionType, type ConferenceAction } from '../ConferenceAction
 import { changeEffect } from './changeEffect'
 import { type ConferenceState } from '../ConferenceState'
 import { filterMediaDevices } from './filterMediaDevices'
+import { closePopUp } from './togglePresentationInPopUp'
+import { notifyJoinConference } from '../../../utils/http-requests'
 
 interface ConnectParams {
   host: string
@@ -157,6 +159,8 @@ export const connect = async (
   }
 
   if (response?.status === 200) {
+    closePopUp()
+    notifyJoinConference().catch(console.error)
     dispatch({
       type: ConferenceActionType.Connected,
       body: {

--- a/webapp/src/App/contexts/ConferenceContext/methods/disconnect.ts
+++ b/webapp/src/App/contexts/ConferenceContext/methods/disconnect.ts
@@ -1,6 +1,8 @@
 import { type DisconnectReason } from '@pexip/infinity'
 import { ConferenceActionType, type ConferenceAction } from '../ConferenceAction'
 import { type ConferenceState } from '../ConferenceState'
+import { closePopUp } from './togglePresentationInPopUp'
+import { notifyLeaveConference } from '../../../utils/http-requests'
 
 export const disconnect = async (
   state: ConferenceState,
@@ -8,6 +10,20 @@ export const disconnect = async (
   reason: DisconnectReason
 ): Promise<void> => {
   state.client?.disconnect({ reason }).catch(console.error)
+
+  closePopUp()
+
+  state.localVideoStream?.getTracks().forEach((track) => {
+    track.stop()
+  })
+  state.localAudioStream?.getTracks().forEach((track) => {
+    track.stop()
+  })
+  state.presentationStream?.getTracks().forEach((track) => {
+    track.stop()
+  })
+
+  notifyLeaveConference().catch(console.error)
 
   dispatch({
     type: ConferenceActionType.Disconnected,


### PR DESCRIPTION
There was an problem with the application lifecycle and some variables when not available when the user clicked on the X or closed the windows.

We use a reference to the function to disconnect and move some code away from the reducer to the disconnect/connect functions.